### PR TITLE
Over-enumeration bugfix

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -225,7 +225,6 @@ function reduce_graph( edges::PsiGraph, graph::PsiGraph=deepcopy(edges), maxit::
    it = 1
    while (newgraph.nodes != graph.nodes || it == 1) && it <= maxit
       if it > 1
-         #println("$it\ngraph: $(length(graph.nodes))")
          graph,newgraph = newgraph,graph
          empty!( newgraph.nodes  )
          empty!( newgraph.length )
@@ -241,9 +240,9 @@ function reduce_graph( edges::PsiGraph, graph::PsiGraph=deepcopy(edges), maxit::
          push_i = false
          for j in 1:length(edges.nodes)
             if hasintersect_terminal( graph.nodes[i], edges.nodes[j] )
+               push_i = true
                const jointset = union( graph.nodes[i], edges.nodes[j] )
                (jointset in newgraph.nodes) && continue
-               push_i = true
                push!( newgraph.nodes,  jointset )
                push!( newgraph.length, graph.length[i] + edges.length[j] )
                push!( newgraph.count,  graph.count[i] + edges.count[j] )

--- a/src/events.jl
+++ b/src/events.jl
@@ -224,10 +224,10 @@ function reduce_graph( edges::PsiGraph, graph::PsiGraph=deepcopy(edges), maxit::
                         graph.min, graph.max )
    it = 1
    jointset = IntSet()
-   function union_joint!( a::IntSet, b::IntSet )
-      empty!(jointset)
-      union!(jointset, a)
-      union!(jointset, b)
+   function union_joint!( js::IntSet, a::IntSet, b::IntSet )
+      empty!(js)
+      union!(js, a)
+      union!(js, b)
    end
    while (newgraph.nodes != graph.nodes || it == 1) && it <= maxit
       if it > 1
@@ -240,7 +240,7 @@ function reduce_graph( edges::PsiGraph, graph::PsiGraph=deepcopy(edges), maxit::
          push_i = false
          for j in 1:length(edges.nodes)
             if hasintersect_terminal( graph.nodes[i], edges.nodes[j] )
-               union_joint!( graph.nodes[i], edges.nodes[j] )
+               union_joint!( jointset, graph.nodes[i], edges.nodes[j] )
                (jointset in newgraph.nodes) && continue
                push_i = true
                push!( newgraph.nodes,  jointset )

--- a/src/events.jl
+++ b/src/events.jl
@@ -223,6 +223,12 @@ function reduce_graph( edges::PsiGraph, graph::PsiGraph=deepcopy(edges), maxit::
                         Vector{Float64}(), Vector{Float64}(),
                         graph.min, graph.max )
    it = 1
+   jointset = IntSet()
+   function union_joint!( a::IntSet, b::IntSet )
+      empty!(jointset)
+      union!(jointset, a)
+      union!(jointset, b)
+   end
    while (newgraph.nodes != graph.nodes || it == 1) && it <= maxit
       if it > 1
          graph,newgraph = newgraph,graph
@@ -234,9 +240,9 @@ function reduce_graph( edges::PsiGraph, graph::PsiGraph=deepcopy(edges), maxit::
          push_i = false
          for j in 1:length(edges.nodes)
             if hasintersect_terminal( graph.nodes[i], edges.nodes[j] )
-               const jointset = union( graph.nodes[i], edges.nodes[j] )
-               push_i = true
+               union_joint!( graph.nodes[i], edges.nodes[j] )
                (jointset in newgraph.nodes) && continue
+               push_i = true
                push!( newgraph.nodes,  jointset )
                push!( newgraph.length, graph.length[i] + edges.length[j] )
                push!( newgraph.count,  graph.count[i] + edges.count[j] )


### PR DESCRIPTION
Some very deep-datasets 100M+ (with overlapping chained AS events) and *certain* indices can over enumerate, causing a hang at the MLE stage.  This PR uses down-sampling to enforce an upper bound to path enumeration.