### PR TITLE
Addition of Dockerfile for version 0.11

### DIFF
--- a/docker/0.11/Dockerfile
+++ b/docker/0.11/Dockerfile
@@ -1,0 +1,23 @@
+##### BASE IMAGE #####
+FROM ubuntu:18.04
+
+# install dependencies
+RUN apt-get update \
+  && apt-get install -y tzdata \
+  && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
+  && dpkg-reconfigure --frontend noninteractive tzdata \
+  && apt-get install --yes make g++ libgslcblas0 libglib2.0-dev libgtk2.0 wget unzip
+
+# install Julia
+RUN wget https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.4-linux-x86_64.tar.gz \
+  && tar xzvf julia-0.6.4-linux-x86_64.tar.gz \
+  && ln -s /julia-9d11f62bcb/bin/julia /usr/bin/julia 
+
+# install Whippet.jl
+RUN julia -e 'Pkg.add("Whippet")' \
+  && julia -e 'using Whippet'
+
+# Clean up
+RUN rm /julia-0.6.4-linux-x86_64.tar.gz
+
+WORKDIR /root/.julia/v0.6/Whippet/bin/


### PR DESCRIPTION
Addition of Dockerfile for version 0.11

Locally it works for me.

The commands are called without the bin prefix as shown below:

`julia whippet-index.jl --help`

and not 

`julia bin/whippet-index.jl --help`

It is also available in dockerhub if someone wants to try it under the following url:
https://hub.docker.com/r/zavolab/whippet/

You can pull it locally as:
`docker pull zavolab/whippet:0.11`